### PR TITLE
Make build-node work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build-browser": "rm -rf build && mkdir build && browserify src/index.js -t [ babelify --presets [ es2015 ] --plugins [ add-module-exports ] ] -p [minifyify --no-map] --standalone TSNE -o build/tsne.min.js",
-    "build-node": "rm -rf dist && node_modules/.bin/babel src --out-dir dist",
+    "build-node": "rm -rf dist && babel src --out-dir dist",
     "build": "npm run build-node && npm run build-browser",
     "prepublish": "npm run build",
     "test": "mocha --reporter spec --compilers js:babel-core/register"


### PR DESCRIPTION
Directly referencing the babel executable makes build-node fail on Windows. Changing it to just reference "babel" fixes this.
